### PR TITLE
No create shell window during build in VS2010

### DIFF
--- a/SemVerHarvester/GitDescribeRunner.cs
+++ b/SemVerHarvester/GitDescribeRunner.cs
@@ -28,7 +28,8 @@ namespace SemVerHarvester
                 FileName = gitPath,
                 Arguments = @"describe --always --long --dirty=-modified --match v[0-9]* --abbrev=7",
                 UseShellExecute = false,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
             };
 
             var process = Process.Start(psi);

--- a/SemVerHarvester/HgLogRunner.cs
+++ b/SemVerHarvester/HgLogRunner.cs
@@ -62,7 +62,8 @@ namespace SemVerHarvester
                 FileName = mercurialPath,
                 Arguments = arguments,
                 UseShellExecute = false,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
             };
 
             var process = Process.Start(psi);


### PR DESCRIPTION
Hi, @jennigs. 

CreateNoWindow = true added to the ProcessStartInfo. It's fixes shell window popup in VS2010.
